### PR TITLE
Allow `push` be called before `init`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ export function init({
 
 // to push custom events
 export function push(args) {
+  window._paq = window._paq || [];
   window._paq.push(args);
 }
 


### PR DESCRIPTION
One may sometimes call `push` before `init`, for example to
setup some parameters such as a custom domain before the
first `trackPageView` call. This one line is all that should be 
needed to support that.