### PR TITLE
Make `isSearchPath` a callback parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ const startsWith = (str: string, needle: string) => {
   return str.substring(0, needle.length) === needle;
 };
 
+const defaultIsSearchPath = (path: string) => startsWith(path, "/recherche") || startsWith(path, "/search")
+
 // initialize the tracker
 export function init({
   url,
@@ -38,6 +40,7 @@ export function init({
   jsTrackerFile = "matomo.js",
   phpTrackerFile = "matomo.php",
   excludeUrlsPatterns = [],
+  isSearchPath = defaultIsSearchPath
 }: InitSettings): void {
   window._paq = window._paq !== null ? window._paq : [];
   if (!url) {
@@ -106,7 +109,7 @@ export function init({
     setTimeout(() => {
       const { q } = Router.query;
       push(["setDocumentTitle", document.title]);
-      if (startsWith(path, "/recherche") || startsWith(path, "/search")) {
+      if (isSearchPath(path)) {
         push(["trackSiteSearch", q ?? ""]);
       } else {
         push(["trackPageView"]);


### PR DESCRIPTION
Force `/recherche` and `/search` pages to be search pages seems really weird, and probably and internal implementation.

This PR opens the discussion about changing this behavior.

I just created a `isSearchPath` callback parameter that keeps your previous behaviour to avoid BC break, but I think that the proper way to do this is to drop a major tag with an empty implementation `(path: string) => false`, or even to have a `searchPath` parameters :

```ts
searchPaths: [
  '/search.html', // for exact match
  /\/recherche/ // for a pattern matching that can replace your `startWith` call
]
```