### PR TITLE
feat(ts): add dimension support

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,11 +1,44 @@
 // / <reference types="next" />
 // / <reference types="next/types/global" />
 
+interface Dimensions {
+  dimension1?: string;
+  dimension2?: string;
+  dimension3?: string;
+  dimension4?: string;
+  dimension5?: string;
+  dimension6?: string;
+  dimension7?: string;
+  dimension8?: string;
+  dimension9?: string;
+  dimension10?: string;
+}
+
 interface Window {
-  _paq?: null | (string | string[] | number | number[])[][];
+  _paq?:
+    | (
+        | Dimensions
+        | number[]
+        | string[]
+        | number
+        | string
+        | null
+        | undefined
+      )[][]
+    | null;
 }
 declare namespace NodeJS {
   interface Global {
-    _paq?: null | (string | string[] | number | number[])[][];
+    _paq?:
+      | (
+          | Dimensions
+          | number[]
+          | string[]
+          | number
+          | string
+          | null
+          | undefined
+        )[][]
+      | null;
   }
 }

--- a/src/__tests__/__snapshots__/matomo.test.ts.snap
+++ b/src/__tests__/__snapshots__/matomo.test.ts.snap
@@ -104,6 +104,22 @@ Array [
 ]
 `;
 
+exports[`push should append dimensions data to window._paq 1`] = `
+Array [
+  Array [
+    "trackEvent",
+    "kikoo",
+    "lol",
+    null,
+    null,
+    Object {
+      "dimension1": "ok",
+      "dimension2": "foobar",
+    },
+  ],
+]
+`;
+
 exports[`router.routeChangeComplete event should track route as search in /recherche 1`] = `
 Array [
   Array [

--- a/src/__tests__/matomo.test.ts
+++ b/src/__tests__/matomo.test.ts
@@ -85,6 +85,20 @@ describe("push", () => {
     push(["trackEvent", "kikoo", "lol"]);
     expect(window._paq).toMatchSnapshot();
   });
+
+  test("should append dimensions data to window._paq", () => {
+    init({ siteId: "42", url: "YO" });
+    window._paq = [];
+    push([
+      "trackEvent",
+      "kikoo",
+      "lol",
+      null,
+      null,
+      { dimension1: "ok", dimension2: "foobar" },
+    ]);
+    expect(window._paq).toMatchSnapshot();
+  });
 });
 
 describe("router.routeChangeStart event", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,31 @@ interface InitSettings {
   excludeUrlsPatterns?: RegExp[];
 }
 
+interface Dimensions {
+  dimension1?: string;
+  dimension2?: string;
+  dimension3?: string;
+  dimension4?: string;
+  dimension5?: string;
+  dimension6?: string;
+  dimension7?: string;
+  dimension8?: string;
+  dimension9?: string;
+  dimension10?: string;
+}
+
 // to push custom events
-export function push(args: (number[] | string[] | number | string)[]): void {
+export function push(
+  args: (
+    | Dimensions
+    | number[]
+    | string[]
+    | number
+    | string
+    | null
+    | undefined
+  )[]
+): void {
   if (!window._paq) {
     window._paq = [];
   }


### PR DESCRIPTION
According to the doc, we can add custom dimensions (and we have to provide all params) to the `push` function. This PR fix Typescript error when we add dimensions (10 supported).

Source: https://developer.matomo.org/guides/tracking-javascript-guide

<img width="961" alt="Capture d’écran 2022-07-11 à 13 58 29" src="https://user-images.githubusercontent.com/1575946/178259212-ba15006e-9ca0-4816-bb43-d93d7df3c8ba.png">

