### PR TITLE
fix: Added flag to opt out of console logging excluded tracks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 node_modules
+.idea

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ interface InitSettings {
   onInitialization?: () => void;
   nonce?: string;
   trustedPolicyName?: string;
+  logExcludedTracks?: boolean;
 }
 
 interface Dimensions {
@@ -82,6 +83,7 @@ export function init({
   onInitialization = undefined,
   nonce,
   trustedPolicyName = "matomo-next",
+  logExcludedTracks = false
 }: InitSettings): void {
   window._paq = window._paq !== null ? window._paq : [];
   if (!url) {
@@ -102,7 +104,7 @@ export function init({
   if (onInitialization) onInitialization();
 
   if (excludedUrl) {
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && logExcludedTracks) {
       console.log(`matomo: exclude track ${window.location.pathname}`);
     }
   } else {


### PR DESCRIPTION
This change resolved  #121 by adding a flag to opt in to having console log for excluded tracks. The console log will **not** be shown by default. 