### PR TITLE
feat: add a callback to know when the script does not load

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The function has three optional callback properties that allow for custom behavi
 
 - `onInitialization`: This callback is triggered when the function is first initialized. It does not receive any parameters. **It could be useful to use it if you want to add parameter to Matomo when the page is render the first time.**
 
+- `onScriptLoadingError`: This callback is triggered when the script does not load. It does not receive any parameters. useful to detect ad-blockers.
+
 ## Tests
 
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ interface InitSettings {
   onRouteChangeStart?: (path: string) => void;
   onRouteChangeComplete?: (path: string) => void;
   onInitialization?: () => void;
+  onScriptLoadingError?: () => void;
   nonce?: string;
   trustedPolicyName?: string;
   logExcludedTracks?: boolean;
@@ -81,6 +82,7 @@ export function init({
   onRouteChangeStart = undefined,
   onRouteChangeComplete = undefined,
   onInitialization = undefined,
+  onScriptLoadingError = undefined,
   nonce,
   trustedPolicyName = "matomo-next",
   logExcludedTracks = false
@@ -137,6 +139,11 @@ export function init({
   scriptElement.defer = true;
   const fullUrl = `${url}/${jsTrackerFile}`;
   scriptElement.src = sanitizer.createScriptURL?.(fullUrl) ?? fullUrl;
+  if (onScriptLoadingError) {
+    scriptElement.onerror = () => {
+      onScriptLoadingError()
+    }
+  }
   if (refElement.parentNode) {
     refElement.parentNode.insertBefore(scriptElement, refElement);
   }


### PR DESCRIPTION
fix #124 

Add the `onScriptLoadingError` callback which is called when the Matomo script can't be loaded (e.g. when an ad blocker is used).