### PR TITLE
[Safeguard] Remove # from being tracked in setCustomUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ onInitialization
   ✓ should work if the surcharge of the operator (1 ms)
 router.routeChangeStart event
   ✓ should setReferrerUrl and setCustomUrl on route change start (1 ms)
+  ✓ should setReferrerUrl and setCustomUrl on route change start and handle hashtag (by removing it)
   ✓ should use previousPath as referer on consecutive route change (1 ms)
   ✓ should work if the surcharge of the operator (3 ms)
 router.routeChangeComplete event

--- a/src/__tests__/matomo.test.ts
+++ b/src/__tests__/matomo.test.ts
@@ -137,6 +137,22 @@ describe("router.routeChangeStart event", () => {
       resolve();
     });
   });
+  test("should setReferrerUrl and setCustomUrl on route change start and handle hashtag (by removing it)", async () => {
+    init({ siteId: "42", url: "YO" });
+    window._paq = [];
+
+    Router.events.emit("routeChangeStart", "/path/to/hello#should-not-appear");
+
+    return new Promise<void>((resolve) => {
+      expect(window._paq).toEqual([
+        ["setReferrerUrl", "/"],
+        ["setCustomUrl", "/path/to/hello"],
+        ["deleteCustomVariables", "page"],
+      ]);
+
+      resolve();
+    });
+  });
   test("should use previousPath as referer on consecutive route change", async () => {
     document.title = "test page 2";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,8 @@ export function init({
 
     // We use only the part of the url without the querystring to ensure piwik is happy
     // It seems that piwik doesn't track well page with querystring
-    const [pathname] = path.split("?");
+    let [pathname] = path.split("?");
+    pathname = pathname.replace(/#.*/, "");
 
     if (previousPath) {
       push(["setReferrerUrl", `${previousPath}`]);


### PR DESCRIPTION
### Description
Safeguard to exclude hashtag and everything that follows. 
In one of my projects, i noticed that the hashtag was somehow being tracked with everything that follows